### PR TITLE
Have wget not check certs as it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ bash ./models/download_model.sh model_name
 For example, to generate Ukiyo-e style images using the pre-trained model,
 
 ```
-bash ./datasets/download_dataset.ukiyoe2photo
+bash ./datasets/download_dataset.sh ukiyoe2photo
 bash ./models/download_model.sh style_ukiyoe
 mkdir ./checkpoints/ukiyoe2photo_pretrained
 mv ./models/style_ukiyoe.t7 ./checkpoints/ukiyoe2photo_pretrained/latest_net_G.t7

--- a/datasets/download_dataset.sh
+++ b/datasets/download_dataset.sh
@@ -8,7 +8,7 @@ fi
 URL=https://people.eecs.berkeley.edu/~taesung_park/CycleGAN/datasets/$FILE.zip
 ZIP_FILE=./datasets/$FILE.zip
 TARGET_DIR=./datasets/$FILE/
-wget -N $URL -O $ZIP_FILE
+wget --no-check-certificate -N $URL -O $ZIP_FILE
 mkdir $TARGET_DIR
 unzip $ZIP_FILE -d ./datasets/
 rm $ZIP_FILE

--- a/models/download_model.sh
+++ b/models/download_model.sh
@@ -5,4 +5,4 @@ echo "Note: available models are apple2orange, facades_photo2label, map2sat, ora
 echo "Specified [$FILE]"
 
 URL=https://people.eecs.berkeley.edu/~taesung_park/CycleGAN/models/$FILE.t7
-wget $URL -O ./models/$FILE.t7
+wget --no-check-certificate $URL -O ./models/$FILE.t7


### PR DESCRIPTION
Was getting this on my local machine when trying to run some of the examples:

```
$ bash ./datasets/download_dataset.sh vangogh2photo
WARNING: timestamping does nothing in combination with -O. See the manual
for details.

--2017-03-31 14:57:26--  https://people.eecs.berkeley.edu/~taesung_park/CycleGAN/datasets/vangogh2photo.zip
Resolving people.eecs.berkeley.edu (people.eecs.berkeley.edu)... 128.32.189.73
Connecting to people.eecs.berkeley.edu (people.eecs.berkeley.edu)|128.32.189.73|:443... connected.
ERROR: cannot verify people.eecs.berkeley.edu's certificate, issued by ‘CN=InCommon RSA Server CA,OU=InCommon,O=Internet2,L=Ann Arbor,ST=MI,C=US’:
  Self-signed certificate encountered.
To connect to people.eecs.berkeley.edu insecurely, use `--no-check-certificate'.
Archive:  ./datasets/vangogh2photo.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of ./datasets/vangogh2photo.zip or
        ./datasets/vangogh2photo.zip.zip, and cannot find ./datasets/vangogh2photo.zip.ZIP, period.
```

Looks like a self-signed cert, adding `--no-check-certificate` to get around it.  Also happened with `download_model.sh`

Also fixed a typo in the README referencing file paths to the shell scripts for downloading.