### PR TITLE
Fixing LuaJit Dependency

### DIFF
--- a/data/dataset.lua
+++ b/data/dataset.lua
@@ -145,7 +145,7 @@ function dataset:__init(...)
    local wc = 'wc'
    local cut = 'cut'
    local find = 'find -H'  -- if folder name is symlink, do find inside it after dereferencing
-   if jit.os == 'OSX' then
+   if package.loaded.libpaths.is_mac() == 'Darwin' then
       wc = 'gwc'
       cut = 'gcut'
       find = 'gfind'


### PR DESCRIPTION
Replacing ```jit.os``` with ```package.loaded.libpaths.is_mac()``` for the OS checking code
addressing the jit usage issue (https://github.com/junyanz/CycleGAN/issues/5)