### PR TITLE
Fix typo in options.lua

### DIFF
--- a/options.lua
+++ b/options.lua
@@ -3,7 +3,7 @@
 --------------------------------------------------------------------------------
 
 local options = {}
--- options for test
+-- options for train
 local opt_train = {
    DATA_ROOT = '',         -- path to images (should have subfolders 'train', 'val', etc)
    batchSize = 1,          -- # images in batch


### PR DESCRIPTION
The comment above opt_train incorrectly stated that it's the options for test