### PR TITLE
adding optnet for memory savings on test

### DIFF
--- a/models/cycle_gan_model.lua
+++ b/models/cycle_gan_model.lua
@@ -2,6 +2,8 @@ local class = require 'class'
 require 'models.base_model'
 require 'models.architectures'
 require 'util.image_pool'
+local optnet = require 'optnet'
+
 util = paths.dofile('../util/util.lua')
 CycleGANModel = class('CycleGANModel', 'BaseModel')
 
@@ -47,6 +49,11 @@ function CycleGANModel:Initialize(opt)
     if opt.test == 1 then -- test mode
       netG_A = util.load_test_model('G_A', opt)
       netG_B = util.load_test_model('G_B', opt)
+
+      --setup optnet to save a little bit of memory
+      local sample_input = torch.randn(1, opt.input_nc, 2, 2)
+      optnet.optimizeMemory(netG_A, sample_input, {inplace=true, reuseBuffers=true})
+      optnet.optimizeMemory(netG_B, sample_input, {inplace=true, reuseBuffers=true})
     else
       netG_A = util.load_model('G_A', opt)
       netG_B = util.load_model('G_B', opt)

--- a/models/one_direction_test_model.lua
+++ b/models/one_direction_test_model.lua
@@ -2,6 +2,8 @@ local class = require 'class'
 require 'models.base_model'
 require 'models.architectures'
 require 'util.image_pool'
+local optnet = require 'optnet'
+
 util = paths.dofile('../util/util.lua')
 OneDirectionTestModel = class('OneDirectionTestModel', 'BaseModel')
 
@@ -21,6 +23,10 @@ function OneDirectionTestModel:Initialize(opt)
 
   -- load/define models
   self.netG_A = util.load_test_model('G', opt)
+
+  -- setup optnet to save a bit of memory
+  local sample_input = torch.randn(1, opt.input_nc, 2, 2)
+  optnet.optimizeMemory(self.netG_A, sample_input, {inplace=true, reuseBuffers=true})
 
   self:RefreshParameters()
 


### PR DESCRIPTION
I added in optnet to the cyclegan and one direction test models for a little bit of memory savings. Using a single model without optnet I was able to generate images around 680px on a Titan. With optnet I was able to get up to 824px. Not huge, but every bit helps!